### PR TITLE
Add redis for Pub/Sub

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -1,0 +1,44 @@
+# Tests
+
+Tests to run for specific functionalities.
+
+---
+
+## Redis pub/sub (event stream)
+
+Verify that the app publishes question/answer/wiki events to Redis without running any agent or SSE client.
+
+### 1. Run the Redis listener
+
+In one terminal (from the project root):
+
+```bash
+npm run test:redis-events
+```
+
+This loads `REDIS_URL` from `.env`, subscribes to all `q:wiki:*` channels, and prints every event. Leave it running.
+
+### 2. Trigger events from the app
+
+With the app running (`npm run dev`), in another terminal or in the browser:
+
+- **Create a question** — e.g. via the UI, or:
+  ```bash
+  curl -X POST http://localhost:3000/api/posts \
+    -H "Content-Type: application/json" \
+    -d '{"poster":"you","header":"Test","content":"Does Redis work?"}'
+  ```
+- **Create a wiki** — via UI or API.
+- **Create an answer** — after you have a post and agent auth (optional).
+
+### 3. What you should see
+
+In the terminal where `npm run test:redis-events` is running, you should see lines like:
+
+```
+[timestamp] q:wiki:general — question.created { ... }
+[timestamp] q:wiki:some-wiki-id — wiki.created { ... }
+[timestamp] q:wiki:general — answer.created { ... }
+```
+
+That confirms the app is publishing to Redis and the script is receiving the same events the SSE route would get. No agent or token is involved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,10 @@
       "name": "ethd-2026",
       "version": "0.1.0",
       "dependencies": {
-        "@openzeppelin/contracts": "^5.4.0",
         "@prisma/client": "^6.19.2",
         "@privy-io/react-auth": "^3.14.1",
         "@privy-io/server-auth": "^1.32.5",
-        "@x402/core": "^2.3.1",
-        "@x402/evm": "^2.3.1",
-        "@x402/fetch": "^2.3.0",
+        "ioredis": "^5.4.2",
         "next": "16.1.6",
         "ngrok": "^5.0.0-beta.2",
         "prisma": "^6.19.2",
@@ -22,7 +19,6 @@
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
-        "solc": "^0.8.34",
         "viem": "^2.46.2"
       },
       "devDependencies": {
@@ -87,6 +83,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1825,6 +1822,12 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2348,6 +2351,7 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -2357,6 +2361,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2577,6 +2582,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2670,12 +2676,6 @@
       "engines": {
         "node": ">=12.4.0"
       }
-    },
-    "node_modules/@openzeppelin/contracts": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.4.0.tgz",
-      "integrity": "sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==",
-      "license": "MIT"
     },
     "node_modules/@paulmillr/qr": {
       "version": "0.2.1",
@@ -5808,6 +5808,7 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -6993,6 +6994,7 @@
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
       "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/codecs": "5.5.1",
@@ -7705,7 +7707,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
       "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -7884,6 +7885,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7995,6 +7997,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -10125,7 +10128,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10222,6 +10224,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10243,6 +10246,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10281,6 +10285,7 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.22.1.tgz",
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -11527,37 +11532,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
-    "node_modules/@x402/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-CWvsf09tslISoVOzQ2TIoBLBP+bUycPsYmmRVe3EV5X2FtD7eXXpiPsiXLEVtWP7zhqLNP/5OIATsA2hSVLSfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^3.24.2"
-      }
-    },
-    "node_modules/@x402/evm": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.3.1.tgz",
-      "integrity": "sha512-aN40OHG0HN1PhBXNFMRi5ISLHsExpF4qIvWUoVMKhFCfaXQDrqsfOKOC3PfcFtK/2Q8/SoiXNN7LsCkChL62lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@x402/core": "~2.3.1",
-        "viem": "^2.39.3",
-        "zod": "^3.24.2"
-      }
-    },
-    "node_modules/@x402/fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@x402/fetch/-/fetch-2.3.0.tgz",
-      "integrity": "sha512-XyY5wcR1gClC5QXJ4ev8O95ZHpiF8UMh5KkMHPYlNqxi59WNXR563XZE8LVoBd/fgRhDdjAoXlqwqBuDL50HOw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@x402/core": "~2.3.0",
-        "viem": "^2.39.3",
-        "zod": "^3.24.2"
-      }
-    },
     "node_modules/abitype": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
@@ -11597,6 +11571,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11928,6 +11903,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -12115,6 +12091,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -12177,6 +12154,7 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -12494,6 +12472,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -12539,12 +12526,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/command-exists": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
-      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -12936,6 +12917,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -13065,6 +13055,7 @@
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.17.tgz",
       "integrity": "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
@@ -13479,6 +13470,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13682,6 +13674,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -14201,7 +14194,8 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
@@ -15111,6 +15105,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.0.tgz",
+      "integrity": "sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -15767,12 +15786,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -16285,6 +16298,18 @@
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -16661,14 +16686,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/merge2": {
@@ -17850,15 +17867,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -18257,6 +18265,7 @@
       "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -18472,6 +18481,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18494,6 +18504,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18578,6 +18589,27 @@
       "resolved": "https://registry.npmjs.org/redaxios/-/redaxios-0.5.1.tgz",
       "integrity": "sha512-FSD2AmfdbkYwl7KDExYQlVvIrFz6Yd83pGfaGjBzM9F6rpq8g652Q4Yq5QD4c+nf4g2AgeElv1y+8ajUPiOYMg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -19227,6 +19259,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -19284,45 +19317,6 @@
         }
       }
     },
-    "node_modules/solc": {
-      "version": "0.8.34",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.34.tgz",
-      "integrity": "sha512-qf8HajA1sHhXRV0hMSDXLjVbc4v3Q+SQbL9zok+1WmgVj7Z4oMjMHxaysCzfGtFVqjZdfDDJWyZI+tcx5bO7Dw==",
-      "license": "MIT",
-      "dependencies": {
-        "command-exists": "^1.2.8",
-        "commander": "^8.1.0",
-        "follow-redirects": "^1.12.1",
-        "js-sha3": "0.8.0",
-        "memorystream": "^0.3.1",
-        "semver": "^5.5.0",
-        "tmp": "0.0.33"
-      },
-      "bin": {
-        "solcjs": "solc.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/solc/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/solc/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -19374,6 +19368,12 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/standardwebhooks": {
@@ -19877,23 +19877,12 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/to-buffer": {
@@ -20127,6 +20116,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20399,6 +20389,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -20409,6 +20400,7 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -20453,6 +20445,7 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "proxy-compare": "^3.0.1"
       },
@@ -20511,6 +20504,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -20619,6 +20613,7 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.5.tgz",
       "integrity": "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "6.2.0",
         "@wagmi/core": "2.22.1",
@@ -20815,6 +20810,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -20957,6 +20953,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:push": "prisma db push",
     "db:migrate:data": "node scripts/migration/migrate-data-to-db.mjs",
     "agent:mcp": "node scripts/runtime/platform-mcp-server.mjs",
-    "agent:mock": "PLATFORM_MCP_PORT=${MOCK_AGENT_PORT:-8787} node scripts/runtime/platform-mcp-server.mjs"
+    "agent:mock": "PLATFORM_MCP_PORT=${MOCK_AGENT_PORT:-8787} node scripts/runtime/platform-mcp-server.mjs",
+    "test:redis-events": "node scripts/test-redis-events.mjs"
   },
   "dependencies": {
     "@prisma/client": "^6.19.2",
@@ -24,7 +25,8 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "viem": "^2.46.2"
+    "viem": "^2.46.2",
+    "ioredis": "^5.4.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/scripts/test-redis-events.mjs
+++ b/scripts/test-redis-events.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Subscribe to Redis event channels and log any question/answer/wiki events.
+ * Use this to verify Redis pub/sub without running any agent or SSE client.
+ *
+ * 1. Start the app: npm run dev
+ * 2. In another terminal: node scripts/test-redis-events.mjs
+ * 3. Create a post (e.g. via UI or curl POST /api/posts) — you should see question.created here.
+ * 4. Create a wiki or answer — you should see wiki.created / answer.created.
+ *
+ * Requires REDIS_URL in .env (or in the environment).
+ */
+
+import { createReadStream } from "fs";
+import { createInterface } from "readline";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import Redis from "ioredis";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..");
+
+// Load .env from project root (simple key=value, no spaces around =)
+async function loadEnv() {
+  const envPath = join(rootDir, ".env");
+  try {
+    const rl = createInterface({
+      input: createReadStream(envPath),
+      crlfDelay: Infinity
+    });
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      process.env[key] = value;
+    }
+  } catch (_) {
+    // .env missing or unreadable
+  }
+}
+
+await loadEnv();
+
+const redisUrl = (process.env.REDIS_URL ?? "").trim();
+if (!redisUrl) {
+  console.error("REDIS_URL is not set. Add it to .env or run REDIS_URL=redis://... node scripts/test-redis-events.mjs");
+  process.exit(1);
+}
+
+const redis = new Redis(redisUrl);
+
+// Subscribe to all wiki event channels (same pattern the app uses: q:wiki:general, q:wiki:*, etc.)
+const pattern = "q:wiki:*";
+await redis.psubscribe(pattern);
+
+console.log(`Subscribed to Redis pattern: ${pattern}`);
+console.log("Create a post, answer, or wiki (via app or API) to see events here. Ctrl+C to exit.\n");
+
+redis.on("pmessage", (_pat, ch, message) => {
+  const ts = new Date().toISOString();
+  try {
+    const payload = JSON.parse(message);
+    const type = payload.eventType ?? "unknown";
+    console.log(`[${ts}] ${ch} — ${type}`, payload);
+  } catch {
+    console.log(`[${ts}] ${ch} — (raw)`, message);
+  }
+});
+
+redis.on("error", (err) => {
+  console.error("Redis error:", err.message);
+});
+
+process.on("SIGINT", () => {
+  redis.quit().then(() => process.exit(0)).catch(() => process.exit(0));
+});

--- a/src/app/api/events/questions/route.ts
+++ b/src/app/api/events/questions/route.ts
@@ -1,15 +1,11 @@
+import Redis from "ioredis";
 import { NextResponse } from "next/server";
 import { listAgentSubscribedWikiIds } from "@/backend/agents/agentStore";
-import { getLatestAnswerAnchor, listAnswersAfterAnchor } from "@/backend/questions/answerStore";
 import { resolveAgentFromRequest } from "@/backend/agents/agentRequestAuth";
-import { getLatestPostAnchor, getPostById, listPostWikiIdsByPostIds, listPostsAfterAnchor } from "@/backend/questions/postStore";
-import { buildAnswerCreatedEvent, buildQuestionCreatedEvent, buildWikiCreatedEvent } from "@/backend/questions/questionEvents";
-import { getLatestWikiAnchor, listWikisAfterAnchor } from "@/backend/wikis/wikiStore";
+import { getLatestPostAnchor, getPostById, listPostsAfterAnchor } from "@/backend/questions/postStore";
+import { buildQuestionCreatedEvent } from "@/backend/questions/questionEvents";
 
 export const runtime = "nodejs";
-// HACK: this stream currently polls the DB on an interval instead of consuming from a queue/bus.
-// Keep for now for simplicity; migrate to push-based fanout before high concurrency traffic.
-const POLL_INTERVAL_MS = 1000;
 
 // Sse data helper.
 function sseData(payload: unknown): string {
@@ -57,15 +53,10 @@ export async function GET(request: Request) {
       let cursor: { id: string; createdAt: string } | null = anchorPost
         ? { id: anchorPost.id, createdAt: anchorPost.createdAt }
         : latestAnchor;
-      let wikiCursor: { id: string; createdAt: string } | null = latestWikiAnchor;
-      let answerCursor: { id: string; createdAt: string } | null = null;
       let closed = false;
-      let polling = false;
 
       // Bootstrap helper.
       const bootstrap = async () => {
-        answerCursor = await getLatestAnswerAnchor();
-
         controller.enqueue(
           encoder.encode(
             sseData({
@@ -89,55 +80,32 @@ export async function GET(request: Request) {
 
       void bootstrap();
 
-      // Poll for new posts, answers, and wikis since the last cursor.
-      const pollForNewPosts = async () => {
-        if (closed || polling) {
-          return;
-        }
-        polling = true;
-        try {
-          const subscribedWikiIds = await listAgentSubscribedWikiIds(agent.id);
-          const newPosts = await listPostsAfterAnchor(cursor, { wikiIds: subscribedWikiIds }, 200);
-          for (const post of newPosts) {
-            if (closed) {
-              return;
-            }
-            controller.enqueue(encoder.encode(sseData(buildQuestionCreatedEvent(post))));
-            cursor = { id: post.id, createdAt: post.createdAt };
-          }
+      const url = String(process.env.REDIS_URL ?? "").trim();
+      const subscribedWikiIds = initialSubscribedWikiIds;
+      const channels =
+        subscribedWikiIds.length > 0
+          ? subscribedWikiIds.map((id) => `q:wiki:${id}`)
+          : ["q:wiki:general"];
+      const subscriber = url ? new Redis(url) : null;
 
-          const newAnswers = await listAnswersAfterAnchor(
-            answerCursor,
-            { wikiIds: subscribedWikiIds, limit: 200 }
-          );
-          const postIds = Array.from(new Set(newAnswers.map((answer) => answer.postId)));
-          const wikiByPostId = await listPostWikiIdsByPostIds(postIds);
-          for (const answer of newAnswers) {
-            if (closed) {
-              return;
-            }
-            const wikiId = wikiByPostId.get(answer.postId) ?? "general";
-            controller.enqueue(encoder.encode(sseData(buildAnswerCreatedEvent(answer, wikiId))));
-            answerCursor = { id: answer.id, createdAt: answer.createdAt };
+      if (subscriber && channels.length > 0) {
+        void (async () => {
+          try {
+            await subscriber.subscribe(...channels);
+            subscriber.on("message", (_channel, message) => {
+              if (closed) {
+                return;
+              }
+              try {
+                const parsed = JSON.parse(message) as unknown;
+                controller.enqueue(encoder.encode(sseData(parsed)));
+              } catch {
+              }
+            });
+          } catch {
           }
-
-          const newWikis = await listWikisAfterAnchor(wikiCursor, 50);
-          for (const wiki of newWikis) {
-            if (closed) {
-              return;
-            }
-            controller.enqueue(encoder.encode(sseData(buildWikiCreatedEvent(wiki))));
-            wikiCursor = { id: wiki.id, createdAt: wiki.createdAt };
-          }
-        } catch {
-        } finally {
-          polling = false;
-        }
-      };
-
-      const pollTimer = setInterval(() => {
-        void pollForNewPosts();
-      }, POLL_INTERVAL_MS);
+        })();
+      }
 
       const keepAlive = setInterval(() => {
         controller.enqueue(encoder.encode(": keepalive\n\n"));
@@ -146,8 +114,15 @@ export async function GET(request: Request) {
       // Close helper.
       const close = () => {
         closed = true;
-        clearInterval(pollTimer);
         clearInterval(keepAlive);
+        if (subscriber) {
+          try {
+            void subscriber.unsubscribe(...channels);
+          } catch {}
+          try {
+            void subscriber.quit();
+          } catch {}
+        }
         try {
           controller.close();
         } catch {}

--- a/src/app/api/posts/[postId]/answers/route.ts
+++ b/src/app/api/posts/[postId]/answers/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { appendAgentActionLog, generateAgentActionId } from "@/backend/agents/agentActionLogStore";
 import { resolveAgentFromRequest } from "@/backend/agents/agentRequestAuth";
 import { addAnswer, listAnswersByPost } from "@/backend/questions/answerStore";
+import { getPostById } from "@/backend/questions/postStore";
+import { publishAnswerCreated } from "@/backend/questions/questionEvents";
 
 export const runtime = "nodejs";
 
@@ -90,6 +92,12 @@ export async function POST(request: Request, props: { params: Promise<{ postId: 
       httpStatus: status
     });
     return NextResponse.json({ error: normalizedError }, { status });
+  }
+
+  const post = await getPostById(params.postId);
+  if (post) {
+    const wikiId = post.wikiId ?? "general";
+    publishAnswerCreated(result.answer, wikiId);
   }
 
   await safeLog({

--- a/src/app/api/wikis/route.ts
+++ b/src/app/api/wikis/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getAuthState } from "@/backend/auth/session";
 import { createWikiRecord, listFeaturedWikis, listWikis, suggestWikis } from "@/backend/wikis/wikiStore";
+import { publishWikiCreated } from "@/backend/questions/questionEvents";
 
 export const runtime = "nodejs";
 
@@ -53,6 +54,8 @@ export async function POST(request: Request) {
   if (!created.ok) {
     return NextResponse.json({ error: created.error }, { status: 400 });
   }
+
+  publishWikiCreated(created.wiki);
 
   return NextResponse.json({ ok: true, wiki: created.wiki }, { status: 201 });
 }

--- a/src/backend/questions/questionEvents.ts
+++ b/src/backend/questions/questionEvents.ts
@@ -1,3 +1,4 @@
+import Redis from "ioredis";
 import type { Answer, Post, Wiki } from "@/types";
 
 export type QuestionCreatedEvent = {
@@ -45,6 +46,29 @@ let nextId = 1;
 // Keep for now while traffic is low; replace with shared pub/sub for multi-instance scale.
 const subscribers = new Map<number, Subscriber>();
 
+let redisClient: any | null = null;
+
+function getRedisClient(): any | null {
+  if (!redisClient) {
+    const url = String(process.env.REDIS_URL ?? "").trim();
+    if (!url) {
+      return null;
+    }
+    redisClient = new Redis(url);
+  }
+  return redisClient;
+}
+
+function publishToBus(wikiId: string | null | undefined, payload: QuestionCreatedEvent | AnswerCreatedEvent | WikiCreatedEvent): void {
+  const client = getRedisClient();
+  if (!client) {
+    return;
+  }
+  const channelWikiId = wikiId && wikiId.trim() ? wikiId.trim() : "general";
+  const channel = `q:wiki:${channelWikiId}`;
+  void client.publish(channel, JSON.stringify(payload));
+}
+
 // Register subscriber and return an unsubscribe handler.
 export function subscribeToQuestionEvents(subscriber: Subscriber): () => void {
   const id = nextId++;
@@ -59,9 +83,21 @@ export function subscribeToQuestionEvents(subscriber: Subscriber): () => void {
 export function publishQuestionCreated(post: Post): void {
   const event = buildQuestionCreatedEvent(post);
 
+  publishToBus(post.wikiId, event);
+
   for (const subscriber of subscribers.values()) {
     subscriber(event);
   }
+}
+
+export function publishAnswerCreated(answer: Answer, wikiId: string): void {
+  const event = buildAnswerCreatedEvent(answer, wikiId);
+  publishToBus(wikiId, event);
+}
+
+export function publishWikiCreated(wiki: Wiki): void {
+  const event = buildWikiCreatedEvent(wiki);
+  publishToBus(wiki.id, event);
 }
 
 // Build question created event payload for downstream use.

--- a/src/types/ioredis.d.ts
+++ b/src/types/ioredis.d.ts
@@ -1,0 +1,5 @@
+declare module "ioredis" {
+  const Redis: any;
+  export default Redis;
+}
+

--- a/test/common.sh
+++ b/test/common.sh
@@ -133,7 +133,8 @@ async function main() {
       verificationStatus: "verified",
       verificationError: null,
       verifiedAt: new Date(process.env.SEED_NOW),
-      capabilities: ["tools"]
+      capabilities: ["tools"],
+      baseWalletAddress: "0x1111111111111111111111111111111111111111"
     }
   });
 }


### PR DESCRIPTION
## Summary by Sourcery

Migrate the questions SSE event stream from database polling to Redis-based pub/sub and integrate Redis-backed event publishing for questions, answers, and wikis.

New Features:
- Add Redis-based pub/sub channels for question, answer, and wiki events keyed by wiki ID.
- Introduce a CLI script and npm script to subscribe to Redis question/answer/wiki event channels for manual verification.

Enhancements:
- Update the SSE questions events API to consume events from Redis channels instead of polling the database.
- Extend question event helpers to publish events both to in-process subscribers and to Redis for cross-instance fanout.
- Trigger Redis-backed publish events when creating answers and wikis so they appear on the event stream.
- Seed test agent data with a base wallet address to support updated capabilities.

Build:
- Add ioredis as a runtime dependency and wire a test script into the npm scripts.

Documentation:
- Add TEST.md with instructions for testing Redis pub/sub event behavior end-to-end.

Tests:
- Add a standalone Redis event listener script to validate that question/answer/wiki events are published correctly over Redis.